### PR TITLE
Call CPUID to serialize instruction execution

### DIFF
--- a/src/rdtsc.c
+++ b/src/rdtsc.c
@@ -2,6 +2,7 @@ extern unsigned long long get_cycles()
 {
     long long out;
     asm volatile(
+        "CPUID;"   /* serialize instruction execution */
         "RDTSCP;"  /* outputs to EDX:EAX and the (unused) cpuid to ECX*/
         "SHLQ $32,%%rdx;"
         "ORQ %%rdx,%%rax;"


### PR DESCRIPTION
Calling `CPUID` to flush the instruction pipeline ensures there are no outstanding instructions executing when the `RDTSC` starts, leading to more accurate measurements.